### PR TITLE
Add 'maintenance' to keywords to check stonith rsc is in maintenance

### DIFF
--- a/hawk_test_ssh.py
+++ b/hawk_test_ssh.py
@@ -39,7 +39,7 @@ class HawkTestSSH:
 
     def verify_stonith_in_maintenance(self, results):
         print("TEST: verify_stonith_in_maintenance")
-        if self.check_cluster_conf_ssh("crm status | grep stonith-sbd", "unmanaged"):
+        if self.check_cluster_conf_ssh("crm status | grep stonith-sbd", ["unmanaged", "maintenance"]):
             print("INFO: stonith-sbd is unmanaged")
             self.set_test_status(results, 'verify_stonith_in_maintenance', 'passed')
             return True


### PR DESCRIPTION
Newer versions of crmsh can be reporting that the stonith-sbd resource is in maintenance by the `maintenance` keyword instead of `unmanaged`:

```
TEST: verify_stonith_in_maintenance
INFO: ssh command [crm status | grep stonith-sbd] got output [  * stonith-sbd   (stonith:external/sbd):  Started hawk-node01 (maintenance)] and error []
ERROR: stonith-sbd is not unmanaged but should be
```

This commit adds `maintenance` so the test checks for both.

This should fix this failing test: https://openqa.suse.de/tests/13713149