### PR TITLE
Update hawk_test*.py file from upstream ClusterLabs

### DIFF
--- a/hawk_test.py
+++ b/hawk_test.py
@@ -75,7 +75,7 @@ def main():
     ssh = HawkTestSSH(args.host, args.secret)
 
     # Get version from /etc/os-release
-    test_version = ssh.ssh.exec_command("grep ^VERSION= /etc/os-release")[1].read().decode().strip().split("=")[1].strip('"')
+    test_version = ssh.ssh.exec_command("grep VERSION= /etc/os-release")[1].read().decode().strip().split("=")[1].strip('"')
 
     # Create driver instance
     browser = HawkTestDriver(addr=args.host, port=args.port,

--- a/hawk_test_driver.py
+++ b/hawk_test_driver.py
@@ -195,12 +195,12 @@ class HawkTestDriver:
                 print(f"ERROR: Couldn't find element by xpath [{xpath}] {errmsg}")
                 self.test_status = False
                 return
-            time.sleep(5)
+            time.sleep(1)
             try:
                 elem.click()
             except ElementNotInteractableException:
                 # Element is obscured. Wait and click again
-                time.sleep(10 * self.timeout_scale)
+                time.sleep(5 * self.timeout_scale)
                 elem.click()
 
     # Generic function to perform the tests
@@ -465,7 +465,7 @@ class HawkTestDriver:
         print(f"INFO: Remove Resource: {name}")
         self.check_edit_conf()
         # resources list does load again after edit configuration page is loaded
-        time.sleep(10)
+        time.sleep(5)
         self.check_and_click_by_xpath(f"Cannot delete resource [{name}]", [Xpath.HREF_DELETE_FORMAT.format(name)])
         time.sleep(2)
         self.check_and_click_by_xpath(f"Cannot confirm delete of resource [{name}]", [Xpath.COMMIT_BTN_DANGER])

--- a/hawk_test_ssh.py
+++ b/hawk_test_ssh.py
@@ -13,7 +13,7 @@ class HawkTestSSH:
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy)
         self.ssh.connect(hostname=hostname.lower(), username="root", password=secret)
 
-    def check_cluster_conf_ssh(self, command, mustmatch):
+    def check_cluster_conf_ssh(self, command, mustmatch, anycheck=False):
         _, out, err = self.ssh.exec_command(command)
         out, err = map(lambda f: f.read().decode().rstrip('\n'), (out, err))
         print(f"INFO: ssh command [{command}] got output [{out}] and error [{err}]")
@@ -21,16 +21,13 @@ class HawkTestSSH:
             print(f"ERROR: got an error over SSH: [{err}]")
             return False
         if isinstance(mustmatch, str):
-            if mustmatch:
-                if mustmatch in out:
-                    return True
-                return False
-            return out == mustmatch
-        if isinstance(mustmatch, list):
-            for exp in mustmatch:
-                if exp not in out:
-                    return False
-            return True
+            return mustmatch in out
+        if isinstance(mustmatch, list) and anycheck:
+            # Output has to match at least one element in the list
+            return any(_ in out for _ in mustmatch)
+        if isinstance(mustmatch, list) and not anycheck:
+            # Output has to match all elements in list
+            return all(_ in out for _ in mustmatch)
         raise ValueError("check_cluster_conf_ssh: mustmatch must be str or list")
 
     @staticmethod
@@ -39,11 +36,11 @@ class HawkTestSSH:
 
     def verify_stonith_in_maintenance(self, results):
         print("TEST: verify_stonith_in_maintenance")
-        if self.check_cluster_conf_ssh("crm status | grep stonith-sbd", "unmanaged"):
-            print("INFO: stonith-sbd is unmanaged")
+        if self.check_cluster_conf_ssh("crm status | grep stonith-sbd", ["unmanaged", "maintenance"], True):
+            print("INFO: stonith-sbd is unmanaged/maintenance")
             self.set_test_status(results, 'verify_stonith_in_maintenance', 'passed')
             return True
-        print("ERROR: stonith-sbd is not unmanaged but should be")
+        print("ERROR: stonith-sbd is not unmanaged nor in maintenance but should be")
         self.set_test_status(results, 'verify_stonith_in_maintenance', 'failed')
         return False
 


### PR DESCRIPTION
here are the changes from ClusterLabs upstream:

- Update hawk for tumbleweed, ruby3.2
- Check rsc stonith is in maintenance by either of 2 keywords

newer versions of crmsh having changed the text indicating the stonith resource, so we need to sync hawk_test*.py files with ClusterLabs (see [TEAM-9186](https://jira.suse.com/browse/TEAM-9186))

**Verification Run**:

- https://openqa.suse.de/tests/14014996
- https://openqa.suse.de/tests/14015821
- https://openqa.suse.de/tests/14015822
- https://openqa.suse.de/tests/14015826
- https://openqa.suse.de/tests/14015830
- https://openqa.suse.de/tests/14015835
- https://openqa.suse.de/tests/14015841